### PR TITLE
The <input/> is in the wrong place

### DIFF
--- a/examples/color-picker/README.md
+++ b/examples/color-picker/README.md
@@ -323,11 +323,11 @@ $ const colors = input.colors;
           color=color
           on-color-selected('handleColorSelected', color)/>
       </div>
-      <input
-        key="hexInput"
-        placeholder="Hex value"
-        on-input('handleHexInput')/>
     </for>
+    <input
+       key="hexInput"
+       placeholder="Hex value"
+       on-input('handleHexInput')/>
   </div>
 </div>
 ```


### PR DESCRIPTION
The `<input/>` tag is in the wrong place, creating an incorrect color picker that doesn't match the tutorial. 

Moving the input outside of the for fixes the issue and matches the color picker tutorial's screenshots.