### PR TITLE
Fix the handleHexInput event

### DIFF
--- a/examples/color-picker/README.md
+++ b/examples/color-picker/README.md
@@ -351,7 +351,7 @@ module.exports = class {
       hexInput = this.input.colors[0];
     }
 
-    this.emit('colorSelected', hexInput);
+    this.emit('color-selected', hexInput);
   }
 };
 


### PR DESCRIPTION
The handleHexInput function was emitting the wrong event. Changed from colorSelected to color-selected so it handles correctly when reaching <color-picker-header>.