### PR TITLE
Clean up names and descriptions of vite examples

### DIFF
--- a/examples/vite-cloudflare-hn/package.json
+++ b/examples/vite-cloudflare-hn/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "marko-hackernews",
-  "description": "Simple Hackernews demo",
+  "name": "marko-vite-cloudflare-hackernews-example",
+  "description": "Hacker News demo with Marko, Vite, and Cloudflare",
   "version": "1.0.0",
   "devDependencies": {
     "@cloudflare/kv-asset-handler": "^0.2.0",

--- a/examples/vite-cloudflare/package.json
+++ b/examples/vite-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "marko-hackernews",
-  "description": "Simple Hackernews demo",
+  "name": "marko-vite-cloudflare-example",
+  "description": "Sample app that demonstrates the power of building UI components using Marko, Vite, and Cloudflare",
   "version": "1.0.0",
   "devDependencies": {
     "@cloudflare/kv-asset-handler": "^0.2.0",

--- a/examples/vite-express/package.json
+++ b/examples/vite-express/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "marko-vite-example",
-  "description": "Sample app that demonstrates the power of building UI components using Marko and Vite",
+  "name": "marko-vite-express-example",
+  "description": "Sample app that demonstrates the power of building UI components using Marko, Vite, and Express",
   "version": "1.0.0",
   "dependencies": {
     "@marko/express": "^1.0.0",

--- a/examples/vite-http/package.json
+++ b/examples/vite-http/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "marko-vite-fastify-example",
-  "description": "Sample app that demonstrates the power of building UI components using Marko, Vite and Fastify",
+  "name": "marko-vite-http-example",
+  "description": "Sample app that demonstrates the power of building UI components using Marko, Vite and an HTTP Server",
   "version": "1.0.0",
   "dependencies": {
     "accepts": "^1.3.7",


### PR DESCRIPTION
While checking out the Vite examples I noticed that a couple had duplicate names and descriptions in their `package.json`'s or didn't exactly following the same naming convention as the example's directory.

This PR suggests the following to distinguish the different examples:

name|description
-----|------------
`marko-vite-cloudflare-hackernews-example`|Hacker News demo with Marko, Vite, and Cloudflare
`marko-vite-cloudflare-example`|Sample app that demonstrates the power of building UI components using Marko, Vite, and Cloudflare
`marko-vite-express-example`|Sample app that demonstrates the power of building UI components using Marko, Vite, and Express
`marko-vite-fastify-example`|Sample app that demonstrates the power of building UI components using Marko, Vite and Fastify
`marko-vite-http-example`|Sample app that demonstrates the power of building UI components using Marko, Vite and an HTTP Server