### PR TITLE
update vite-cloudflare example so it works

### DIFF
--- a/examples/vite-cloudflare/package.json
+++ b/examples/vite-cloudflare/package.json
@@ -10,7 +10,7 @@
     "marko": "^5.17.9",
     "postcss-preset-env": "^7.2.0",
     "rimraf": "^3.0.2",
-    "undici": "^4.12.1",
+    "undici": "^5.5.1",
     "url-router": "^13.0.0",
     "vite": "^2.7.10"
   },

--- a/examples/vite-cloudflare/wrangler.toml
+++ b/examples/vite-cloudflare/wrangler.toml
@@ -1,16 +1,12 @@
 
 name = "marko-cloudflare"
-type = "javascript"
+main = "dist/worker.js"
 workers_dev = true
 compatibility_date = "2022-01-06"
 
 [site]
 bucket = "./dist"
-entry-point = ""
 include = ["assets/**"]
 
 [build]
 command = "npm run build"
-
-[build.upload]
-format = "service-worker"


### PR DESCRIPTION
before these changes there was a serious security issue with one of the imported libraries

undici  4.8.2 - 5.5.0
Severity: high
ProxyAgent vulnerable to MITM - https://github.com/advisories/GHSA-pgw7-wx7w-2w33

and the latest wrangler cli tool couldn't find the output js file since it has changed its expectations about the format of the wrangler.toml file