### PR TITLE
include js files as route entry

### DIFF
--- a/examples/vite-cloudflare-hn/src/router.js
+++ b/examples/vite-cloudflare-hn/src/router.js
@@ -1,6 +1,8 @@
 import Router from "url-router";
 
-const entries = import.meta.globEager("./pages/*(!(components/*)*/)*.marko");
+const entries = import.meta.globEager(
+  "./pages/*(!(components/*)*/)*.(marko|js)"
+);
 const routes = {};
 
 for (const entry in entries) {

--- a/examples/vite-cloudflare/src/router.js
+++ b/examples/vite-cloudflare/src/router.js
@@ -1,6 +1,8 @@
 import Router from "url-router";
 
-const entries = import.meta.globEager("./pages/*(!(components/*)*/)*.marko");
+const entries = import.meta.globEager(
+  "./pages/*(!(components/*)*/)*.(marko|js)"
+);
 const routes = {};
 
 for (const entry in entries) {


### PR DESCRIPTION
As mentioned in the readme of vite examples, we can re-export marko components from `.js` files.