### PR TITLE
Explicit file extensions in imports

### DIFF
--- a/examples/language-guide/src/components/dynamic-tagname/dynamic-component.marko
+++ b/examples/language-guide/src/components/dynamic-tagname/dynamic-component.marko
@@ -1,5 +1,5 @@
-import Hello from "./components/hello"
-import Goodbye from "./components/goodbye"
+import Hello from "./components/hello.marko"
+import Goodbye from "./components/goodbye.marko"
 
 $ const isLeaving = false;
 <${isLeaving ? Goodbye : Hello} name="Frank"/>

--- a/examples/language-guide/src/components/import/import.marko
+++ b/examples/language-guide/src/components/import/import.marko
@@ -1,4 +1,4 @@
-import { add, subtract } from "./helper"
+import { add, subtract } from "./helper.js"
 
 <p>1 + 2 = ${add(1, 2)}</p>
 <p>2 - 1 = ${subtract(2, 1)}</p>


### PR DESCRIPTION
Without the `.marko`, the Try Online editor for `components/dynamic-component.marko` shows:

> **Error**
> Unable to resolve "./components/hello" from "/components/dynamic-tagname/dynamic-component.marko".
> _Open the dev tools to view the full error._

This fixes that, and adds a `.js` to `components/import.marko` for consistency.