### PR TITLE
fix(app): repair the template's test and lint scripts

### DIFF
--- a/examples/app/.prettierignore
+++ b/examples/app/.prettierignore
@@ -6,3 +6,4 @@ coverage
 dist
 node_modules
 package-lock.json
+pnpm-lock.yaml

--- a/examples/app/vitest.config.ts
+++ b/examples/app/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     coverage: {
       enabled: isCI,
       provider: "istanbul",
-      include: ["src/**/*"],
+      include: ["src/**/*.{ts,marko}"],
     },
     projects: [
       {


### PR DESCRIPTION
Two config-level bugs that break the `app` template's own scripts on a freshly generated project. Neither is a Marko runtime or compiler issue.

**`npm test` under CI** — `coverage.include: ["src/**/*"]` matched every file, so `@vitest/coverage-istanbul` pushed `src/routes/+meta.json` and `src/tags/char-count/styles.module.css` through babel when it reported on files no test imported (`SyntaxError: Missing semicolon`, and `Coverage must be initialized with a path or an object`). Coverage is gated on `isCI`, so this only ever failed in CI. Narrowed to the extensions that actually hold code.

**`npm run lint`** — pnpm writes single-quoted yaml, so `pnpm-lock.yaml` is never prettier-clean and can't be: `pnpm install` rewrites it on every dependency change. `package-lock.json` was already ignored; this adds the pnpm equivalent, matching what marko-js/vite, marko-js/cli and marko-js/language-server each do.

Verified on a fresh install of this template with the current published deps: `CI=true vitest run` goes from exit 1 to exit 0 with coverage still reported for `.ts` and `.marko` (including un-imported route templates), and `npm run lint` passes and stays passing after `pnpm add` rewrites the lockfile.

Not ignoring `pnpm-workspace.yaml`: it's hand-editable config rather than a generated lockfile, prettier is happy with it as pnpm writes it today, and none of the Marko repos ignore it.